### PR TITLE
Add PFC-JSONL to Backend > Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ Logging
 * [loki github](https://github.com/grafana/loki) - Loki: like Prometheus, but for logs.
 * [elasticsearch](https://www.elastic.co/cn/products/elasticsearch) - Open Source, Distributed, RESTful Search Engine, written in java.
 * [elasticsearch github](https://github.com/elastic/elasticsearch) - Elastic stack.
+* [pfc-jsonl](https://github.com/ImpossibleForge/pfc-jsonl) - JSONL log compressor with block-level timestamp indexing for cold log archival; ~9% ratio, DuckDB queryable, Fluent Bit compatible.
 
 Tracing
 


### PR DESCRIPTION
Adds PFC-JSONL to the Backend > Logging section.

PFC-JSONL is a JSONL log compressor with block-level timestamp indexing — the cold storage tier for log pipelines using Fluent Bit and Loki/Elasticsearch.

- ~9% compression ratio (vs gzip ~12%, zstd ~14%) — cuts S3 log archival costs
- DuckDB queryable: `INSTALL pfc FROM community; LOAD pfc;`
- Fluent Bit compatible via pfc-fluentbit forwarder
- pfc-gateway: HTTP REST server — query cold archives from Grafana, curl, Python
- Migration tools: pfc-migrate (gzip/bz2/zstd/lz4 → PFC) and pfc-convert (Apache/nginx/CSV → PFC)