### PR TITLE
Add Linuxfabrik monitoring-plugins to Nagios Monitoring Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Monitoring tools based on nagios.
 
 * [monitoring-plugins](https://www.monitoring-plugins.org/) - Monitoring plugins official website.
 * [monitoring-plugins github](https://github.com/monitoring-plugins) - Monitoring plugins source code.
+* [Linuxfabrik monitoring-plugins](https://linuxfabrik.github.io/monitoring-plugins/) - 230+ plugins for Icinga, Nagios and compatible systems, written in Python for all platforms.
+* [Linuxfabrik monitoring-plugins github](https://github.com/Linuxfabrik/monitoring-plugins) - Linuxfabrik monitoring plugins source code.
 
 #### Develop Plugins
 


### PR DESCRIPTION
Adds the Linuxfabrik monitoring-plugins collection to the "Nagios Monitoring Plugins" category.

- Project: https://linuxfabrik.github.io/monitoring-plugins/
- Source: https://github.com/Linuxfabrik/monitoring-plugins

230+ standalone plugins for Icinga, Nagios and compatible monitoring systems, written in Python, running on all platforms with minimal dependencies. Adheres to the contribution guidelines: official website + source code link, appended to the bottom of the relevant category.